### PR TITLE
feat: disable pushing to main branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-branch=$(git symbolic-ref --short HEAD); if [ "$branch" = '' ]; then echo 'Pushing to main is not allowed'; exit 1; fi
+branch=$(git symbolic-ref --short HEAD); if [ "$branch" = 'main' ]; then echo 'Pushing to main is not allowed'; exit 1; fi


### PR DESCRIPTION
i have created a husky script for commit linting and code quality pushing to the main branch directly is not possible 